### PR TITLE
Fix marker file race condition (for most purposes)

### DIFF
--- a/pkg/build2/filesystem.go
+++ b/pkg/build2/filesystem.go
@@ -468,30 +468,33 @@ func OpenFilesystemBuildCache(dir filesystem.MutableDirectory, config dbconfig.B
 		config: []dbconfig.BuildDatabaseConfig{config},
 	}
 
-	if err := checkMarkerFile(dir); err != nil && !errors.Is(err, fs.ErrNotExist) {
+	err := checkMarkerFile(dir)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return nil, fmt.Errorf("failed to check marker file: %w", err)
 	}
 
-	// Create the marker file
-	markerFile := filesystem.Factory.NewMemoryFile()
-	markerFileHandle, err := markerFile.OpenMut()
-	if err != nil {
-		return nil, fmt.Errorf("failed to open marker file: %w", err)
-	}
+	if errors.Is(err, fs.ErrNotExist) {
+		// Create the marker file
+		markerFile := filesystem.Factory.NewMemoryFile()
+		markerFileHandle, err := markerFile.OpenMut()
+		if err != nil {
+			return nil, fmt.Errorf("failed to open marker file: %w", err)
+		}
 
-	markerHeader := MarkerHeader{
-		Version: MARKET_VERSION,
-	}
+		markerHeader := MarkerHeader{
+			Version: MARKET_VERSION,
+		}
 
-	if err := json.NewEncoder(markerFileHandle).Encode(markerHeader); err != nil {
+		if err := json.NewEncoder(markerFileHandle).Encode(markerHeader); err != nil {
+			markerFileHandle.Close()
+			return nil, fmt.Errorf("failed to encode marker file: %w", err)
+		}
+
 		markerFileHandle.Close()
-		return nil, fmt.Errorf("failed to encode marker file: %w", err)
-	}
 
-	markerFileHandle.Close()
-
-	if _, err := dir.Create(MARKER_FILENAME, markerFile); err != nil {
-		return nil, fmt.Errorf("failed to create marker file: %w", err)
+		if _, err := dir.Create(MARKER_FILENAME, markerFile); err != nil {
+			return nil, fmt.Errorf("failed to create marker file: %w", err)
+		}
 	}
 
 	return ret, nil


### PR DESCRIPTION
This pull request fixes the race conditions in marker file for the situation where the marker file already exists. It does not fix the potential issue that could occur if someone runs Tinyrange twice concurrently when a marker file doesn't exist; that would require performing an atomic file write. But that should be an exceedingly unlikely situation.

Apologies that this is so far behind the alpha branch. I'll sync if needed to merge (I've run out of time right now).