### PR TITLE
Run fsck before mounting persistent volumes

### DIFF
--- a/pkg/vmm/driver.go
+++ b/pkg/vmm/driver.go
@@ -1739,6 +1739,23 @@ type volumeInfo struct {
 	Persist       bool
 }
 
+func buildMountScript(volumes []volumeInfo, resize bool) string {
+	mountNames := []string{"vdb", "vdc", "vdd", "vde", "vdf", "vdg"}
+	script := "def main():\n"
+	for i, volume := range volumes {
+		dev := fmt.Sprintf("/dev/%s", mountNames[i])
+		if volume.Persist {
+			script += fmt.Sprintf("  if \"run\" in dir() and path_exists(\"/sbin/fsck.ext4\"):\n")
+			script += fmt.Sprintf("    run(\"/sbin/fsck.ext4\", \"-p\", \"%s\")\n", dev)
+		}
+		script += fmt.Sprintf("  mount(\"ext4\", \"%s\", \"%s\", ensure_path = True)\n", dev, volume.GuestPath)
+		if resize {
+			script += fmt.Sprintf("  linux_ext4_try_resize(\"%s\")\n", volume.GuestPath)
+		}
+	}
+	return script
+}
+
 func (d *driver) startFileShare(mountedHostDirectories []mountInfo) error {
 	if feature.HasFeature(feature.Feature9P) {
 		for _, dir := range mountedHostDirectories {
@@ -2050,18 +2067,7 @@ func (d *driver) exec(create func(vmm Driver) (VirtualMachineMonitor, error)) er
 				return fmt.Errorf("failed to ensure path: %w", err)
 			}
 
-			mountNames := []string{"vdb", "vdc", "vdd", "vde", "vdf", "vdg"}
-
-			mountScript := "def main():\n"
-			for i, volume := range volumes {
-				mountScript += fmt.Sprintf(
-					"  mount(\"ext4\", \"/dev/%s\", \"%s\", ensure_path = True)\n",
-					mountNames[i], volume.GuestPath,
-				)
-				if feature.HasFeature(feature.FeatureExt4Resize) {
-					mountScript += fmt.Sprintf("  linux_ext4_try_resize(\"%s\")\n", volume.GuestPath)
-				}
-			}
+			mountScript := buildMountScript(volumes, feature.HasFeature(feature.FeatureExt4Resize))
 
 			if err := rootFilesystem.WriteFile("/init.d/mount.star", []byte(mountScript)); err != nil {
 				return fmt.Errorf("failed to write file: %w", err)

--- a/pkg/vmm/driver_test.go
+++ b/pkg/vmm/driver_test.go
@@ -1,0 +1,31 @@
+package vmm
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildMountScriptFsck(t *testing.T) {
+	volumes := []volumeInfo{
+		{VolumeName: "vol1", GuestPath: "/data", Persist: true},
+		{VolumeName: "vol2", GuestPath: "/cache", Persist: false},
+	}
+	script := buildMountScript(volumes, false)
+
+	if !strings.Contains(script, "\"run\" in dir() and path_exists(\"/sbin/fsck.ext4\")") {
+		t.Fatalf("fsck run check missing: %s", script)
+	}
+	if strings.Count(script, "fsck.ext4") != 1 {
+		t.Fatalf("expected fsck check only for persistent volume: %s", script)
+	}
+	mountIdx := strings.Index(script, "mount(\"ext4\", \"/dev/vdb\", \"/data\"")
+	fsckIdx := strings.Index(script, "fsck.ext4")
+	if fsckIdx > mountIdx {
+		t.Fatalf("fsck should run before mount: %s", script)
+	}
+	if idx := strings.Index(script, "/dev/vdc"); idx != -1 {
+		if strings.Contains(script[idx:], "fsck.ext4") {
+			t.Fatalf("non-persistent volume should not run fsck: %s", script)
+		}
+	}
+}

--- a/tests/basic/persist_fsck.yml
+++ b/tests/basic/persist_fsck.yml
@@ -1,0 +1,6 @@
+version: 1
+builder: alpine@3.22
+commands:
+  - echo hello > /test/hello.txt
+volumes:
+  - trTestFsck,128,/test,persist


### PR DESCRIPTION
## Summary
- ensure init scripts only run fsck when both `run` builtin and `fsck.ext4` are available
- validate generated Starlark script performs fsck before mounting
- add basic test YAML exercising a persistent volume

## Testing
- `go fmt ./...`
- `go test ./...` *(fails: pattern init: no matching files found; module download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bff3ab43848333bf0c3ae75675a39e